### PR TITLE
Rename contents of the repo to match repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Core Team Minutes
+# Competition Team Minutes
 
-Minutes from the [Core Team][core-team] meetings.
+Minutes from the [Competition Team][competition-team] meetings.
 
 The canonical instance of this repository is on github at
-https://github.com/srobo/core-team-minutes.
+https://github.com/srobo/competition-team-minutes.
 
 Actions from each meeting are recorded as [issues][github-issues] on the github
 instance. There is a Python script to support this:
@@ -14,8 +14,8 @@ The script requires Python 3.5+ and the [requests][python-requests] library. It
 uses the [GitHub REST API v3][github-rest-api], for which you should create a
 [Personal Access Token][api-tokens] with scope `repo:public_repo`.
 
-[core-team]: https://srobo.gitbook.io/ops-manual/annual-robotics-competition/core-team
-[github-issues]: https://github.com/srobo/core-team-minutes/issues
+[competition-team]: https://opsmanual.studentrobotics.org/annual-robotics-competition/competition-programme-team
+[github-issues]: https://github.com/srobo/competition-team-minutes/issues
 [python-requests]: https://pypi.org/project/requests
 [github-rest-api]: https://developer.github.com/v3/issues/
 [api-tokens]: https://blog.github.com/2013-05-16-personal-api-tokens/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Minutes from the [Competition Team][competition-team] meetings.
 The canonical instance of this repository is on github at
 https://github.com/srobo/competition-team-minutes.
 
+For the SR2019 season, this team was called the "Core Team".
+
 Actions from each meeting are recorded as [issues][github-issues] on the github
 instance. There is a Python script to support this:
 ```

--- a/scripts/parse_actions.py
+++ b/scripts/parse_actions.py
@@ -3,7 +3,7 @@ import typing
 import urllib.parse
 
 REPO_OWNER = 'srobo'
-REPO_NAME = 'core-team-minutes'
+REPO_NAME = 'competition-team-minutes'
 
 Action = typing.NamedTuple('Action', (
     ('id', typing.Optional[int]),

--- a/template.md
+++ b/template.md
@@ -1,4 +1,4 @@
-# Core Team Meeting YYYY-MM-DD 00:00
+# Competition Team Meeting YYYY-MM-DD 00:00
 
 ## Attendees
 

--- a/template.md
+++ b/template.md
@@ -12,8 +12,7 @@
 
 ## Agenda
 
-1. Previous minutes: https://github.com/srobo/core-team-minutes/tree/master/2018/YYYY-MM-DD.md
-2.
+1. ...
 
 ## Minutes
 


### PR DESCRIPTION
This renames the current aspects of the contents, but deliberately leaves the old links as they were.