### PR TITLE
Add minutes from 2021-01-14

### DIFF
--- a/.name_map.json
+++ b/.name_map.json
@@ -13,5 +13,6 @@
     "sedders123": ["James"],
     "HopeShaw": ["Hope"],
     "trickeydan": ["Dan"],
-    "Tyler-Ward": ["Tyler"]
+    "Tyler-Ward": ["Tyler"],
+    "WillB97": ["Will"]
 }

--- a/SR2021/2021-01-14.md
+++ b/SR2021/2021-01-14.md
@@ -24,7 +24,7 @@
   - Will: prepare assets for this, ideally some videos of the new things, stills are fine too
 - When will the new version be available?
   - Immediately is good, but not a requirement
-  - We_do_ need to be able to say when it will be available
+  - We _do_ need to be able to say when it will be available
   - Need to ensure that the time is fair with regards to timezones
 - Let’s work this out backwards from when it’s completed. Review that tomorrow evening!
 

--- a/SR2021/2021-01-14.md
+++ b/SR2021/2021-01-14.md
@@ -54,9 +54,9 @@
 
 ## Action Points
 
-* Will: prepare assets for module 2 announcement, ideally some videos of the new things, stills are fine too
-* Jake: prepare presentation for module 2 announcement
-* Peter: check the competition website supports two-team arenas
-* Jake: update the overlay to support two-team arenas
-* Jake: sort Will an @sr account (and/or poke Diane)
-* Jenny: draft a rules update
+* Will: prepare assets for module 2 announcement, ideally some videos of the new things, stills are fine too ([#253](https://github.com/srobo/competition-team-minutes/issues/253))
+* Jake: prepare presentation for module 2 announcement ([#254](https://github.com/srobo/competition-team-minutes/issues/254))
+* Peter: check the competition website supports two-team arenas ([#255](https://github.com/srobo/competition-team-minutes/issues/255))
+* Jake: update the overlay to support two-team arenas ([#256](https://github.com/srobo/competition-team-minutes/issues/256))
+* Jake: sort Will an @sr account (and/or poke Diane) ([#257](https://github.com/srobo/competition-team-minutes/issues/257))
+* Jenny: draft a rules update ([#258](https://github.com/srobo/competition-team-minutes/issues/258))

--- a/SR2021/2021-01-14.md
+++ b/SR2021/2021-01-14.md
@@ -1,0 +1,62 @@
+# Competition Team Meeting 2021-01-14
+
+## Attendees
+
+### Present
+
+* Andy Barrett-Sprot
+* Jake Howard
+* James Seden Smith
+* Jenny Fletcher
+* Peter Law (minutes)
+* Will Barber
+
+## Topics
+
+### How to announce Module 2?
+
+- In the livestream at the end of the module 1 league livestream?
+  - We can extract this to its own video too
+  - We should have a blog post too
+- What assets do we need for the announcement?
+  - Some form of visuals
+  - Think we can use the images/mockups we have already from the PRs
+  - Will: prepare assets for this, ideally some videos of the new things, stills are fine too
+- When will the new version be available?
+  - Immediately is good, but not a requirement
+  - We_do_ need to be able to say when it will be available
+  - Need to ensure that the time is fair with regards to timezones
+- Let’s work this out backwards from when it’s completed. Review that tomorrow evening!
+
+### Anything outstanding for running Module 1 league
+
+- No schedule as yet
+  - Blocked on knowing which teams are competing, blocked until code submission
+  - Check Alistair is aware of the plan here
+- Check the competition website handles two-team arenas
+  - Peter to check this
+- Update the overlay to work with two-team arenas
+  - Jake to update this
+
+### Practicalities of running Module 1 league
+
+- Once submissions are in, we’ll generate the schedule
+- We’re happy to have the producer (Jake) also be one of the commentators
+- Will & James will be running the matches
+  - Need to grant access to push to compstate for the person simulating the matches
+  - Need to grant access to upload to the drive
+- Alistair & Jake will be commentating
+
+### Finalising Module 2
+
+- Need a rules update
+- There are various simulator PRs in flight
+
+## Action Points
+
+* Will: prepare assets for module 2 announcement, ideally some videos of the new things, stills are fine too
+* Jake: prepare presentation for module 2 announcement
+* Peter: check the competition website supports two-team arenas
+* Jake: update the overlay to support two-team arenas
+* Jake: sort Will an @sr account (and/or poke Diane)
+* Jenny: draft a rules update

--- a/template.md
+++ b/template.md
@@ -1,0 +1,31 @@
+# Competition Team Meeting YYYY-MM-DD
+
+## Attendees
+
+### Present
+
+-
+
+### Apologies
+
+-
+
+## Agenda
+
+1. ...
+
+## Topics
+
+1. Minutes to be reviewed in relevant pull request on GitHub
+2.
+
+
+## Action Points
+
+### General
+
+-
+
+### Specific
+
+-


### PR DESCRIPTION
This also reinstates the template as that's needed for the canonical flow, even if you use the markdown converter.